### PR TITLE
Remove an unnecessary `println` and use UUIDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "actix-web-requestid"
 description = "Request ID middleware for actix-web"
-version = "0.3.1"
-authors = ["Pierre-Alexandre St-Jean <pa@stjean.me>"]
+version = "0.3.2"
+authors = ["Pierre-Alexandre St-Jean <pa@stjean.me>", "Charles German <5donuts@protonmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/pastjean/actix-web-requestid"
@@ -15,8 +15,8 @@ edition = "2018"
 codecov = { repository = "pastjean/actix-web-requestid", branch = "master", service = "github" }
 
 [dependencies]
-actix-web = "3.0.1"
-rand = "0.7.3"
+actix-web = "3.3"
+uuid = { version = "0.8", features = ["v4"] }
 futures = "0.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "actix-web-requestid"
 description = "Request ID middleware for actix-web"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Pierre-Alexandre St-Jean <pa@stjean.me>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this to your Cargo.toml:
 
 ```toml
 [dependencies]
-actix-web-requestid = "0.3.0"
+actix-web-requestid = "0.3.1"
 ```
 
 And this to your crate root:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,6 @@ where
             let val = HeaderValue::from_str(&req_id).unwrap();
             res.headers_mut().insert(name, val);
 
-            println!("{:?}", res.headers());
             Ok(res)
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,16 +21,15 @@
 //! ```
 extern crate actix_web;
 extern crate futures;
-extern crate rand;
+extern crate uuid;
 
 use actix_web::dev::{Payload, Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::http::{HeaderName, HeaderValue};
 use actix_web::{Error, FromRequest, HttpMessage, HttpRequest};
 use futures::future::{ok, Future, Ready};
-use rand::distributions::Alphanumeric;
-use rand::Rng;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use uuid::Uuid;
 
 /// The header set by the middleware
 pub const REQUEST_ID_HEADER: &str = "request-id";
@@ -77,10 +76,11 @@ where
             return id.0.clone();
         }
 
-        let id: String = rand::thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(10)
-            .collect::<String>();
+        let id = String::from(
+            Uuid::new_v4()
+                .to_hyphenated()
+                .encode_lower(&mut Uuid::encode_buffer()),
+        );
         self.extensions_mut().insert(RequestIDItem(id.clone()));
 
         id


### PR DESCRIPTION
This line can clutter your logs with messages, especially if you use something like `tracing` to generate logs to be consumed by another service (e.g., [`tracing-bunyan-formatter`](https://crates.io/crates/tracing-bunyan-formatter) and [`bunyan`](https://github.com/trentm/node-bunyan)).