### PR TITLE
Do not request default features from actix-web

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 codecov = { repository = "pastjean/actix-web-requestid", branch = "master", service = "github" }
 
 [dependencies]
-actix-web = "^4.5.1"
+actix-web = { version = "^4.5.1", default-features = false }
 rand = "^0.8.5"
 
 [dev-dependencies]


### PR DESCRIPTION
This crate does not depend on any of the features in actix-web. Since features are additive, another crate cannot optimize the use of actix-web to a smaller feature set as long as there is one crate implicitly requesting the default feature set of actix-web.